### PR TITLE
check IS_ADMIN_FLAG, not if function defined

### DIFF
--- a/includes/modules/payment/authorizenet_cim.php
+++ b/includes/modules/payment/authorizenet_cim.php
@@ -1669,8 +1669,10 @@ VALUES (:nameFull, :amount, :type, now(), :mod, :transID, :paymentProfileID, :ap
 
         function cimUpdatedByAdminName()
         {
-            if (function_exists('zen_updated_by_admin')) {
+            if (IS_ADMIN_FLAG === true) {
                 return zen_updated_by_admin();
+            } else {
+               return "";
             }
         }
 


### PR DESCRIPTION
Fixes #55 
Backwards compatible with older Zen Cat releases.

If not done, the updated_by field in 1.5.8 will contain: Unknown Name[]. 
![image](https://user-images.githubusercontent.com/4391638/155242094-36021acd-febf-4312-b410-d3efb6b4bba2.png)