### PR TITLE
Use class order_status

### DIFF
--- a/includes/modules/payment/authorizenet_cim.php
+++ b/includes/modules/payment/authorizenet_cim.php
@@ -1634,7 +1634,7 @@
                         $logData .= " Code : " . $tresponse->getMessages()[0]->getCode() . "\n";
                         $logData .= " Description : " . $tresponse->getMessages()[0]->getDescription() . "\n";
                         $diffBetCaptAndAuth = $this->capturePayment($transactionid, $amount);
-                        $this->updateOrderInfo($_POST['oID'], MODULE_PAYMENT_AUTHORIZENET_CIM_ORDER_STATUS_ID, $diffBetCaptAndAuth);
+                        $this->updateOrderInfo($_POST['oID'], $this->order_status, $diffBetCaptAndAuth);
                     } else {
                         $logData = "Transaction Failed \n";
                         if ($tresponse->getErrors() != null) {


### PR DESCRIPTION
The database setting `MODULE_PAYMENT_AUTHORIZENET_CIM_ORDER_STATUS_ID` might be 0 (which does not correspond to an order status, and will lead to a log in `orders.php`).  But `$this->order_status` is protected against being set to 0 in the constructor. 